### PR TITLE
Workaround when no graphics device is available (PDF output)

### DIFF
--- a/server.R
+++ b/server.R
@@ -577,7 +577,7 @@ shinyServer(function(input, output, session) {
         filename = "plot.pdf",
         content = function(file) {
             # write pdf of ggplot
-            ggsave(filename=file, width=200, height=150, unit="mm")
+            ggsave(filename=file, device=pdf(NULL), width=200, height=150, unit="mm")
         }
     )
     


### PR DESCRIPTION
If no graphics device is available (eg. inside a docker container) the PDF output will fail.

> Warning: Error in <Anonymous>: cannot open file 'Rplots.pdf'

I don't know if there is a better solution or if there are any disadvantages on devices that have graphics hardware. Anyway, it now works on docker, shinyapps.io, AWS, etc.

